### PR TITLE
Fix missing cover images after CSV import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -275,8 +275,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251202.0.tgz",
       "integrity": "sha512-Q7m1Ivu2fbKalOPm00KLpu6GfRaq4TlrPknqugvZgp/gDH96OYKINO4x7jvCIBvCz/aK9vVoOj8tlbSQBervVA==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2577,7 +2576,6 @@
       "integrity": "sha512-fvDz8o7SQpFLoSBo6Cudv+fE85/fPCkwTnLAN85M+Jv7k59w2mSIjT9Q5px7XwGrmYqqKBEYxh/09IBGd1E7AQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.14",
         "fflate": "^0.8.2",
@@ -2650,7 +2648,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4140,7 +4137,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.7.tgz",
       "integrity": "sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4720,7 +4716,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5080,7 +5075,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -5617,7 +5611,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -6246,7 +6239,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6340,7 +6332,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6455,7 +6446,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6506,7 +6496,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -6589,7 +6578,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7174,7 +7162,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7230,7 +7217,6 @@
       "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.14",
         "@vitest/mocker": "4.0.14",
@@ -7457,7 +7443,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -8164,7 +8149,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/handlers/enrichment-queue-consumer.ts
+++ b/src/handlers/enrichment-queue-consumer.ts
@@ -1,27 +1,29 @@
 /**
  * Enrichment Queue Consumer
  *
- * Processes ISBNs from the enrichment queue and writes data to Alexandria.
- * This ensures CSV imports (which bypass the normal enrichment pipeline)
- * still contribute to Alexandria's knowledge base.
+ * Processes ISBNs from the enrichment queue, fetches metadata from providers,
+ * and updates both Alexandria and the user's library (D1/KV) with enriched data.
  *
  * Queue Flow:
  *   CSV Import → BookRepository.save() → ENRICHMENT_QUEUE.send()
- *                                              ↓
+ *                     (no cover)                  ↓
  *                              enrichment-queue-consumer (this file)
  *                                              ↓
  *                              enrichMultipleBooks() → Alexandria
+ *                                              ↓
+ *                              updateLibraryWithCover() → D1/KV (cover URLs)
  *
  * Benefits:
  * - CSV imports remain fast (no enrichment blocking)
  * - Alexandria learns from user imports (eventual consistency)
+ * - User library gets cover images after async enrichment
  * - Proper ExecutionContext for waitUntil() operations
- * - User CSV data gets priority in provider chain
  *
- * Related: Issue #XXX - Alexandria doesn't learn from CSV imports
+ * Related: Fix for cover images not showing after CSV import
  */
 
 import { enrichMultipleBooks } from "../services/enrichment.js"
+import { BookRepository } from "../repositories/book-repository.js"
 import type { Env } from "../types/env.js"
 import type {
   MessageBatch,
@@ -90,9 +92,21 @@ export async function processEnrichmentBatch(
       )
 
       if (result.works.length > 0) {
+        const work = result.works[0]
+        const edition = result.editions?.[0]
+        const coverUrl = edition?.coverImageURL || work?.coverImageURL
+
         console.log(
-          `[Enrichment Queue] ✅ Enriched ISBN ${isbn}: ${result.works[0].title} (provider: ${result.works[0].primaryProvider})`,
+          `[Enrichment Queue] ✅ Enriched ISBN ${isbn}: ${work.title} (provider: ${work.primaryProvider})`,
         )
+
+        // Update the user's library (D1/KV) with cover URLs
+        if (coverUrl) {
+          await updateLibraryWithCover(isbn, coverUrl, result, env)
+        } else {
+          console.log(`[Enrichment Queue] ⚠️ No cover URL found for ISBN ${isbn}`)
+        }
+
         successCount++
       } else {
         // Book not found in any provider - this is OK, not an error
@@ -124,5 +138,82 @@ export async function processEnrichmentBatch(
       doubles: [successCount, failedCount, skippedCount, duration],
       indexes: ["enrichment_queue"],
     })
+  }
+}
+
+/**
+ * Update user's library (D1/KV) with cover URLs from enrichment
+ *
+ * This bridges the gap between:
+ * 1. CSV import (saves books without covers)
+ * 2. Background enrichment (fetches covers from providers)
+ *
+ * Strategy:
+ * - Fetch existing book from library (preserves user data like ratings)
+ * - Merge enriched cover URLs into existing record
+ * - Save back to D1/KV
+ *
+ * @param isbn - ISBN to update
+ * @param coverUrl - Primary cover URL from enrichment
+ * @param enrichmentResult - Full enrichment result with works/editions/authors
+ * @param env - Worker environment bindings
+ */
+async function updateLibraryWithCover(
+  isbn: string,
+  coverUrl: string,
+  enrichmentResult: { works: any[]; editions: any[]; authors: any[] },
+  env: Env,
+): Promise<void> {
+  try {
+    const bookRepo = new BookRepository(env)
+
+    // Fetch existing book to preserve user data (ratings, notes, etc.)
+    const existingBook = await bookRepo.findByISBN(isbn)
+
+    if (!existingBook) {
+      console.log(`[Enrichment Queue] Book ${isbn} not found in library, skipping cover update`)
+      return
+    }
+
+    // Check if cover already exists (avoid unnecessary updates)
+    if (existingBook.coverMediumUrl || existingBook.coverLargeUrl) {
+      console.log(`[Enrichment Queue] Book ${isbn} already has cover, skipping update`)
+      return
+    }
+
+    // Extract best available cover URLs from enrichment
+    const edition = enrichmentResult.editions?.[0]
+    const work = enrichmentResult.works?.[0]
+
+    // Merge enriched data into existing book
+    const updatedBook = {
+      ...existingBook,
+      // Cover URLs (prefer edition over work)
+      coverSmallUrl: edition?.coverImageURL || work?.coverImageURL || coverUrl,
+      coverMediumUrl: edition?.coverImageURL || work?.coverImageURL || coverUrl,
+      coverLargeUrl: edition?.coverImageURL || work?.coverImageURL || coverUrl,
+      // Update canonical metadata with enriched data
+      canonicalMetadata: {
+        ...existingBook.canonicalMetadata,
+        works: enrichmentResult.works.length > 0
+          ? enrichmentResult.works
+          : existingBook.canonicalMetadata?.works || [],
+        editions: enrichmentResult.editions.length > 0
+          ? enrichmentResult.editions
+          : existingBook.canonicalMetadata?.editions || [],
+        authors: enrichmentResult.authors.length > 0
+          ? enrichmentResult.authors
+          : existingBook.canonicalMetadata?.authors || [],
+      },
+      updatedAt: Math.floor(Date.now() / 1000),
+    }
+
+    // Save updated book back to D1/KV
+    await bookRepo.save(updatedBook)
+
+    console.log(`[Enrichment Queue] 📚 Updated library with cover for ISBN ${isbn}: ${coverUrl.substring(0, 60)}...`)
+  } catch (error) {
+    // Non-fatal: log but don't fail the enrichment
+    console.error(`[Enrichment Queue] ⚠️ Failed to update library for ISBN ${isbn}:`, error)
   }
 }

--- a/src/handlers/enrichment-queue-consumer.ts
+++ b/src/handlers/enrichment-queue-consumer.ts
@@ -25,6 +25,7 @@
 import { enrichMultipleBooks } from "../services/enrichment.js"
 import { BookRepository } from "../repositories/book-repository.js"
 import type { Env } from "../types/env.js"
+import type { WorkDTO, EditionDTO, AuthorDTO } from "../types/canonical.js"
 import type {
   MessageBatch,
   ExecutionContext,
@@ -161,7 +162,7 @@ export async function processEnrichmentBatch(
 async function updateLibraryWithCover(
   isbn: string,
   coverUrl: string,
-  enrichmentResult: { works: any[]; editions: any[]; authors: any[] },
+  enrichmentResult: { works: WorkDTO[]; editions: EditionDTO[]; authors: AuthorDTO[] },
   env: Env,
 ): Promise<void> {
   try {
@@ -176,28 +177,24 @@ async function updateLibraryWithCover(
     }
 
     // Check if cover already exists (avoid unnecessary updates)
-    if (existingBook.coverMediumUrl || existingBook.coverLargeUrl) {
+    if (existingBook.coverSmallUrl || existingBook.coverMediumUrl || existingBook.coverLargeUrl) {
       console.log(`[Enrichment Queue] Book ${isbn} already has cover, skipping update`)
       return
     }
 
-    // Extract best available cover URLs from enrichment
-    const edition = enrichmentResult.editions?.[0]
-    const work = enrichmentResult.works?.[0]
-
     // Merge enriched data into existing book
     const updatedBook = {
       ...existingBook,
-      // Cover URLs (prefer edition over work)
-      coverSmallUrl: edition?.coverImageURL || work?.coverImageURL || coverUrl,
-      coverMediumUrl: edition?.coverImageURL || work?.coverImageURL || coverUrl,
-      coverLargeUrl: edition?.coverImageURL || work?.coverImageURL || coverUrl,
+      // Cover URLs (coverUrl already contains edition?.coverImageURL || work?.coverImageURL)
+      coverSmallUrl: coverUrl,
+      coverMediumUrl: coverUrl,
+      coverLargeUrl: coverUrl,
       // Update canonical metadata with enriched data
+      // Note: works.length > 0 is guaranteed by caller (line 95)
       canonicalMetadata: {
         ...existingBook.canonicalMetadata,
-        works: enrichmentResult.works.length > 0
-          ? enrichmentResult.works
-          : existingBook.canonicalMetadata?.works || [],
+        works: enrichmentResult.works,
+        // Preserve existing metadata if enrichment didn't find editions/authors
         editions: enrichmentResult.editions.length > 0
           ? enrichmentResult.editions
           : existingBook.canonicalMetadata?.editions || [],

--- a/tests/handlers/enrichment-queue-consumer.test.ts
+++ b/tests/handlers/enrichment-queue-consumer.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Unit tests for enrichment-queue-consumer
+ *
+ * Tests the processEnrichmentBatch function and updateLibraryWithCover helper.
+ * Verifies that background enrichment correctly updates user libraries with cover images.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { processEnrichmentBatch } from '../../src/handlers/enrichment-queue-consumer.ts'
+import type { MessageBatch, ExecutionContext } from '@cloudflare/workers-types'
+import type { Env } from '../../src/types/env.js'
+
+// Mock the enrichMultipleBooks service
+vi.mock('../../src/services/enrichment.js', () => ({
+  enrichMultipleBooks: vi.fn(),
+}))
+
+// Create a mock book repository instance
+const mockBookRepoInstance = {
+  findByISBN: vi.fn(),
+  save: vi.fn(),
+}
+
+// Mock the BookRepository
+vi.mock('../../src/repositories/book-repository.js', () => ({
+  BookRepository: vi.fn(function() {
+    return mockBookRepoInstance
+  }),
+}))
+
+import { enrichMultipleBooks } from '../../src/services/enrichment.js'
+import { BookRepository } from '../../src/repositories/book-repository.js'
+
+// Helper to create mock environment
+const createMockEnv = (): Env => ({
+  PERFORMANCE_ANALYTICS: {
+    writeDataPoint: vi.fn(),
+  },
+  BOOK_CACHE: {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+  },
+  D1: {
+    prepare: vi.fn().mockReturnValue({
+      bind: vi.fn().mockReturnThis(),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+      run: vi.fn().mockResolvedValue({ success: true }),
+    }),
+  },
+} as unknown as Env)
+
+// Helper to create mock execution context
+const createMockContext = (): ExecutionContext => ({
+  waitUntil: vi.fn(),
+  passThroughOnException: vi.fn(),
+})
+
+// Helper to create mock queue message
+const createMockMessage = (isbn: string, source = 'csv_import') => ({
+  id: `msg-${isbn}`,
+  timestamp: new Date(),
+  body: {
+    entity_type: 'edition' as const,
+    isbn,
+    source: source as 'csv_import' | 'batch_enrichment' | 'scan_import',
+    priority: 5,
+  },
+  ack: vi.fn(),
+  retry: vi.fn(),
+})
+
+describe('processEnrichmentBatch', () => {
+  let mockEnv: Env
+  let mockCtx: ExecutionContext
+
+  beforeEach(() => {
+    mockEnv = createMockEnv()
+    mockCtx = createMockContext()
+
+    // Reset mocks
+    vi.clearAllMocks()
+  })
+
+  describe('Basic queue processing', () => {
+    it('should process batch of messages and update analytics', async () => {
+      const messages = [
+        createMockMessage('9780439708180'),
+        createMockMessage('9780451524935'),
+      ]
+
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      // Mock enrichMultipleBooks to return successful results
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: 'https://example.com/cover.jpg',
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [],
+        authors: [],
+      })
+
+      // Mock findByISBN to return no existing book (will skip update)
+      mockBookRepoInstance.findByISBN.mockResolvedValue(null)
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Verify messages were acknowledged
+      expect(messages[0].ack).toHaveBeenCalled()
+      expect(messages[1].ack).toHaveBeenCalled()
+
+      // Verify analytics were logged
+      expect(mockEnv.PERFORMANCE_ANALYTICS.writeDataPoint).toHaveBeenCalledWith(
+        expect.objectContaining({
+          blobs: ['enrichment_queue', 'batch_processed'],
+          indexes: ['enrichment_queue'],
+        }),
+      )
+    })
+
+    it('should skip messages without ISBN', async () => {
+      const messages = [createMockMessage('')]
+      messages[0].body.isbn = '' // Invalid ISBN
+
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Should ack but not enrich
+      expect(messages[0].ack).toHaveBeenCalled()
+      expect(enrichMultipleBooks).not.toHaveBeenCalled()
+    })
+
+    it('should retry failed enrichments', async () => {
+      const messages = [createMockMessage('9780439708180')]
+
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      // Mock enrichMultipleBooks to throw error
+      vi.mocked(enrichMultipleBooks).mockRejectedValue(new Error('Provider timeout'))
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Should retry, not ack
+      expect(messages[0].retry).toHaveBeenCalled()
+      expect(messages[0].ack).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateLibraryWithCover (via integration)', () => {
+    it('should update library with cover URL when book exists and has no cover', async () => {
+      const isbn = '9780439708180'
+      const messages = [createMockMessage(isbn)]
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      const coverUrl = 'https://covers.openlibrary.org/b/isbn/9780439708180-L.jpg'
+
+      // Mock enrichMultipleBooks to return result with cover
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: coverUrl,
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [],
+        authors: [],
+      })
+
+      // Mock findByISBN to return existing book without cover
+      mockBookRepoInstance.findByISBN.mockResolvedValue({
+        isbn,
+        title: 'Harry Potter',
+        coverSmallUrl: null,
+        coverMediumUrl: null,
+        coverLargeUrl: null,
+        canonicalMetadata: {
+          works: [],
+          editions: [],
+          authors: [],
+        },
+      })
+
+      // Mock save to succeed
+      mockBookRepoInstance.save.mockResolvedValue(undefined)
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Verify findByISBN was called
+      expect(mockBookRepoInstance.findByISBN).toHaveBeenCalledWith(isbn)
+
+      // Verify save was called with updated book
+      expect(mockBookRepoInstance.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isbn,
+          coverSmallUrl: coverUrl,
+          coverMediumUrl: coverUrl,
+          coverLargeUrl: coverUrl,
+          canonicalMetadata: expect.objectContaining({
+            works: expect.arrayContaining([
+              expect.objectContaining({
+                title: 'Harry Potter',
+              }),
+            ]),
+          }),
+        }),
+      )
+    })
+
+    it('should skip update when book not found in library', async () => {
+      const isbn = '9780439708180'
+      const messages = [createMockMessage(isbn)]
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      // Mock enrichMultipleBooks to return result with cover
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: 'https://example.com/cover.jpg',
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [],
+        authors: [],
+      })
+
+      // Mock findByISBN to return null (book not in library)
+      mockBookRepoInstance.findByISBN.mockResolvedValue(null)
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Verify save was NOT called
+      expect(mockBookRepoInstance.save).not.toHaveBeenCalled()
+
+      // Message should still be acknowledged
+      expect(messages[0].ack).toHaveBeenCalled()
+    })
+
+    it('should skip update when book already has covers', async () => {
+      const isbn = '9780439708180'
+      const messages = [createMockMessage(isbn)]
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      // Mock enrichMultipleBooks to return result with cover
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: 'https://example.com/new-cover.jpg',
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [],
+        authors: [],
+      })
+
+      // Mock findByISBN to return book with existing cover
+      mockBookRepoInstance.findByISBN.mockResolvedValue({
+        isbn,
+        title: 'Harry Potter',
+        coverSmallUrl: 'https://example.com/old-cover-small.jpg',
+        coverMediumUrl: 'https://example.com/old-cover-medium.jpg',
+        coverLargeUrl: 'https://example.com/old-cover-large.jpg',
+      })
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Verify save was NOT called
+      expect(mockBookRepoInstance.save).not.toHaveBeenCalled()
+
+      // Message should still be acknowledged
+      expect(messages[0].ack).toHaveBeenCalled()
+    })
+
+    it('should preserve existing user data (ratings, notes) during update', async () => {
+      const isbn = '9780439708180'
+      const messages = [createMockMessage(isbn)]
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      const coverUrl = 'https://example.com/cover.jpg'
+
+      // Mock enrichMultipleBooks
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: coverUrl,
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [],
+        authors: [],
+      })
+
+      // Mock findByISBN to return book with user data
+      mockBookRepoInstance.findByISBN.mockResolvedValue({
+        isbn,
+        title: 'Harry Potter',
+        rating: 5,
+        notes: 'My favorite book!',
+        readStatus: 'read',
+        coverSmallUrl: null,
+        coverMediumUrl: null,
+        coverLargeUrl: null,
+        canonicalMetadata: {
+          works: [],
+          editions: [],
+          authors: [],
+        },
+      })
+
+      mockBookRepoInstance.save.mockResolvedValue(undefined)
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Verify save was called with preserved user data
+      expect(mockBookRepoInstance.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isbn,
+          rating: 5,
+          notes: 'My favorite book!',
+          readStatus: 'read',
+          coverSmallUrl: coverUrl,
+          coverMediumUrl: coverUrl,
+          coverLargeUrl: coverUrl,
+        }),
+      )
+    })
+
+    it('should handle errors gracefully without failing enrichment', async () => {
+      const isbn = '9780439708180'
+      const messages = [createMockMessage(isbn)]
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      // Mock enrichMultipleBooks to succeed
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: 'https://example.com/cover.jpg',
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [],
+        authors: [],
+      })
+
+      // Mock findByISBN to throw error
+      mockBookRepoInstance.findByISBN.mockRejectedValue(new Error('Database connection lost'))
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Message should still be acknowledged (non-fatal error)
+      expect(messages[0].ack).toHaveBeenCalled()
+    })
+
+    it('should preserve existing canonical metadata when enrichment returns empty arrays', async () => {
+      const isbn = '9780439708180'
+      const messages = [createMockMessage(isbn)]
+      const batch: MessageBatch<any> = {
+        queue: 'ENRICHMENT_QUEUE',
+        messages,
+      }
+
+      const coverUrl = 'https://example.com/cover.jpg'
+
+      // Mock enrichMultipleBooks with work but no editions/authors
+      vi.mocked(enrichMultipleBooks).mockResolvedValue({
+        works: [
+          {
+            title: 'Harry Potter',
+            subjectTags: ['fantasy'],
+            coverImageURL: coverUrl,
+            goodreadsWorkIDs: [],
+            amazonASINs: [],
+            librarythingIDs: [],
+            googleBooksVolumeIDs: [],
+            isbndbQuality: 100,
+            reviewStatus: 'pending',
+            primaryProvider: 'google_books',
+          },
+        ],
+        editions: [], // Empty!
+        authors: [], // Empty!
+      })
+
+      // Mock existing book with canonical metadata
+      const existingEdition = {
+        isbn,
+        title: 'Harry Potter',
+        format: 'hardcover',
+        isbns: [isbn],
+        amazonASINs: [],
+        googleBooksVolumeIDs: [],
+        librarythingIDs: [],
+        isbndbQuality: 100,
+        primaryProvider: 'google_books',
+      }
+      const existingAuthor = {
+        name: 'J.K. Rowling',
+        gender: 'female',
+      }
+
+      mockBookRepoInstance.findByISBN.mockResolvedValue({
+        isbn,
+        title: 'Harry Potter',
+        coverSmallUrl: null,
+        coverMediumUrl: null,
+        coverLargeUrl: null,
+        canonicalMetadata: {
+          works: [],
+          editions: [existingEdition],
+          authors: [existingAuthor],
+        },
+      })
+
+      mockBookRepoInstance.save.mockResolvedValue(undefined)
+
+      await processEnrichmentBatch(batch, mockEnv, mockCtx)
+
+      // Verify existing editions/authors were preserved
+      expect(mockBookRepoInstance.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          canonicalMetadata: expect.objectContaining({
+            editions: [existingEdition],
+            authors: [existingAuthor],
+          }),
+        }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
…chment

The enrichment queue consumer was fetching cover images from providers (Google Books, OpenLibrary, ISBNdb) and storing them in Alexandria, but never updating the user's library (D1/KV) with the cover URLs.

This caused cover images to not show in the library after CSV import, even though the enrichment was completing successfully in the background.

Changes:
- Import BookRepository to enrichment-queue-consumer.ts
- Add updateLibraryWithCover() helper function
- After successful enrichment, update D1/KV with cover URLs
- Preserve existing user data (ratings, notes) during updates
- Skip update if book already has covers (avoid unnecessary writes)

Flow after fix:
CSV Import → Save books (no covers) → Queue ISBNs
                                          ↓
                    Background Enrichment → Alexandria
                                          ↓
                    updateLibraryWithCover() → D1/KV (covers)