### PR TITLE
perf(v3): convert dynamic imports to static (#192)

### DIFF
--- a/src/api-v3/index.ts
+++ b/src/api-v3/index.ts
@@ -29,6 +29,8 @@ import { createProblemDetails } from '@bookstrack/schemas/errors'
 import { findBooksByTitle, findBookByISBN } from '../services/book-service'
 import { normalizeTitle } from '../utils/normalization'
 import { extractUniqueAuthors, removeAuthorsFromWorks, enrichAuthorsWithCulturalData } from '../utils/response-transformer'
+import { enrichMultipleBooks } from '../services/enrichment'
+import { generateBookEmbedding, storeEmbedding } from '../services/embedding-service'
 
 // Constants for V3 API data transformation
 const DEFAULT_PROVIDER_QUALITY = 95 // Default quality score for provider data
@@ -285,10 +287,6 @@ for semantic search.`,
     console.log(`[V3 Enrich] ISBNs: ${isbns.length}, includeEmbedding: ${includeEmbedding}`)
 
     try {
-      // Import enrichment services
-      const { enrichMultipleBooks } = await import('../services/enrichment')
-      const { generateBookEmbedding, storeEmbedding } = await import('../services/embedding-service')
-
       const enrichedBooks: EnrichedBook[] = []
       const notFound: string[] = []
 


### PR DESCRIPTION
Resolves #192 - Eliminates dynamic imports from V3 API for better performance.

**Changes:**
- Add static imports for enrichMultipleBooks, generateBookEmbedding, storeEmbedding
- Remove dynamic import statements from batch enrichment handler

**Performance Impact:**
- ✅ Zero import overhead (functions pre-loaded)
- ✅ Faster Workers cold starts
- ✅ Better tree-shaking

**Verified:**
- ✅ Smoke tests pass
- ✅ Batch enrichment tests pass
- ✅ No dynamic imports remain